### PR TITLE
🛡️ Sentinel: [security improvement] Add HTTP Security Headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-03 - Security Headers Implementation
+**Vulnerability:** Missing HTTP Security Headers (X-Frame-Options, HSTS, etc.)
+**Learning:** Next.js requires explicit configuration in `next.config.ts` headers() function to serve security headers.
+**Prevention:** Use a standard set of security headers for all Next.js projects to prevent common attacks like clickjacking and MIME sniffing.

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,43 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'X-DNS-Prefetch-Control',
+            value: 'on'
+          },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload'
+          },
+          {
+            key: 'X-XSS-Protection',
+            value: '1; mode=block'
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'SAMEORIGIN'
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff'
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'origin-when-cross-origin'
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=(), browsing-topics=()'
+          }
+        ]
+      }
+    ]
+  }
 };
 
 export default nextConfig;


### PR DESCRIPTION
Added standard HTTP security headers to `next.config.ts` to enhance application security posture. Headers include HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, and Permissions-Policy. Also initialized the Sentinel security journal.

---
*PR created automatically by Jules for task [5446912241723791396](https://jules.google.com/task/5446912241723791396) started by @fakhriaditiarahman*