### PR TITLE
🛡️ Sentinel: Add Security Headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal
+
+## 2024-05-22 - Security Headers Enhancement
+**Vulnerability:** The application was missing Content Security Policy (CSP), X-Permitted-Cross-Domain-Policies, and X-XSS-Protection headers.
+**Learning:** While Next.js provides some security headers by default (like X-Frame-Options), it does not enforce a Content Security Policy or other hardening headers out of the box because they can break application functionality if not carefully configured.
+**Prevention:** Always implement a strict Content Security Policy and other security headers (X-XSS-Protection, X-Permitted-Cross-Domain-Policies) in `next.config.ts` or middleware to reduce the attack surface against XSS and other injection attacks.Regularly audit and update these headers as the application evolves.

--- a/next.config.ts
+++ b/next.config.ts
@@ -28,7 +28,19 @@ const nextConfig: NextConfig = {
           },
           {
             key: 'Permissions-Policy',
-            value: 'camera=(), microphone=(), geolocation=()'
+            value: 'camera=(), microphone=(), geolocation=(), browsing-topics=()'
+          },
+          {
+            key: 'X-XSS-Protection',
+            value: '1; mode=block'
+          },
+          {
+            key: 'X-Permitted-Cross-Domain-Policies',
+            value: 'none'
+          },
+          {
+            key: 'Content-Security-Policy',
+            value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;"
           }
         ]
       }


### PR DESCRIPTION
Enhanced application security by adding HTTP response headers in `next.config.ts`.
This change enforces a Content Security Policy (CSP) to mitigate XSS and other injection attacks, and adds several other hardening headers like `X-Permitted-Cross-Domain-Policies` and `X-XSS-Protection`.
Also created a security journal in `.jules/sentinel.md` documenting this enhancement.

---
*PR created automatically by Jules for task [1676378288978066290](https://jules.google.com/task/1676378288978066290) started by @fakhriaditiarahman*