### PR TITLE
🛡️ Sentinel: [SECURITY] Refine Content Security Policy to remove unsafe-eval

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** The application was missing Content Security Policy (CSP), X-Permitted-Cross-Domain-Policies, and X-XSS-Protection headers.
 **Learning:** While Next.js provides some security headers by default (like X-Frame-Options), it does not enforce a Content Security Policy or other hardening headers out of the box because they can break application functionality if not carefully configured.
 **Prevention:** Always implement a strict Content Security Policy and other security headers (X-XSS-Protection, X-Permitted-Cross-Domain-Policies) in `next.config.ts` or middleware to reduce the attack surface against XSS and other injection attacks.Regularly audit and update these headers as the application evolves.
+
+## 2025-02-08 - Content Security Policy Refinement
+**Vulnerability:** The Content Security Policy allowed `'unsafe-eval'` in all environments, which increases the attack surface for XSS attacks if an attacker can inject script.
+**Learning:** While `'unsafe-eval'` is often necessary for development tools (like webpack HMR), it is rarely needed in production for modern React applications. Removing it significantly hardens the application.
+**Prevention:** Use environment checks (e.g., `process.env.NODE_ENV === 'development'`) to conditionally include relaxed CSP directives like `'unsafe-eval'` only when strictly necessary for development, enforcing a stricter policy in production.

--- a/next.config.ts
+++ b/next.config.ts
@@ -40,7 +40,18 @@ const nextConfig: NextConfig = {
           },
           {
             key: 'Content-Security-Policy',
-            value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;"
+            value: `
+              default-src 'self';
+              script-src 'self' ${process.env.NODE_ENV === 'development' ? "'unsafe-eval'" : ""} 'unsafe-inline';
+              style-src 'self' 'unsafe-inline';
+              img-src 'self' blob: data:;
+              font-src 'self';
+              object-src 'none';
+              base-uri 'self';
+              form-action 'self';
+              frame-ancestors 'none';
+              upgrade-insecure-requests;
+            `.replace(/\s{2,}/g, ' ').trim()
           }
         ]
       }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The Content Security Policy previously allowed `'unsafe-eval'` in all environments. This increases the attack surface for XSS attacks by allowing the execution of arbitrary code strings.
🎯 Impact: If an attacker can inject a script (via XSS), they can execute arbitrary code even if `unsafe-inline` is blocked (though it's currently allowed). Removing `unsafe-eval` is a critical defense-in-depth measure.
🔧 Fix: Updated `next.config.ts` to conditionally include `'unsafe-eval'` only when `process.env.NODE_ENV === 'development'`. In production, it is strictly removed.
✅ Verification: Ran `npm run build` to ensure the configuration is valid and the build succeeds. Verified via code review.

---
*PR created automatically by Jules for task [15992895600409046894](https://jules.google.com/task/15992895600409046894) started by @fakhriaditiarahman*