### PR TITLE
🛡️ Sentinel: [HIGH] Enforce strict CSP with nonces

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,8 @@
 **Vulnerability:** The static CSP in `next.config.ts` relied on `'unsafe-inline'` for scripts, exposing the app to XSS risks.
 **Learning:** To implement a strict CSP with nonce support for App Router, we must use Edge Middleware (now renamed to `proxy` in Next.js 16+). The `middleware.ts` file convention is deprecated in favor of `proxy.ts`, and the export must be named `proxy`.
 **Prevention:** Use `src/proxy.ts` to generate nonces and set dynamic CSP headers, allowing the removal of `'unsafe-inline'` from `script-src`. Ensure `style-src` retains `'unsafe-inline'` if using libraries like Framer Motion that inject styles at runtime.
+
+## 2026-02-20 - Strict CSP Implementation in Next.js Middleware
+**Vulnerability:** The application had a `src/proxy.ts` file intended for CSP, but it explicitly allowed `'unsafe-inline'` in `script-src` and failed to utilize the generated nonce, effectively bypassing XSS protections.
+**Learning:** Merely generating a nonce in middleware is insufficient; it must be explicitly added to the `script-src` directive (e.g., `'nonce-${nonce}'`) and passed to Next.js via request headers (`x-nonce`) for internal scripts to pick it up. Modern browsers ignore `'unsafe-inline'` when a nonce or `'strict-dynamic'` is present.
+**Prevention:** Construct the `script-src` directive dynamically in `src/proxy.ts` to include `'nonce-${nonce}'` and `'strict-dynamic'`, ensuring robust XSS protection while maintaining backward compatibility.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -11,6 +11,8 @@ export function proxy(request: NextRequest) {
   // - 'unsafe-eval': Only in development for Hot Module Replacement
   const scriptSrc = [
     "'self'",
+    `'nonce-${nonce}'`,
+    "'strict-dynamic'",
     "'unsafe-inline'",
     process.env.NODE_ENV === 'development' ? "'unsafe-eval'" : ""
   ].filter(Boolean).join(' ')


### PR DESCRIPTION
This PR hardens the application's Content Security Policy (CSP) by enforcing the use of nonces for script execution.

**Changes:**
- Updated `src/proxy.ts` to include `nonce-${nonce}` and `strict-dynamic` in the `script-src` directive.
- This effectively disables `unsafe-inline` for scripts in modern browsers, preventing XSS attacks that rely on injecting inline script tags.
- Verified that the application builds and runs correctly, and that the nonce is properly propagated to the HTML script tags.

**Verification:**
- `npm run build` passes.
- `curl -v http://localhost:3000` confirms the presence of `nonce` in both the CSP header and the HTML script tags.


---
*PR created automatically by Jules for task [15997695100087034185](https://jules.google.com/task/15997695100087034185) started by @fakhriaditiarahman*