### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix CSP XSS vulnerability by enforcing nonce and strict-dynamic

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,8 @@
 **Vulnerability:** The static CSP in `next.config.ts` relied on `'unsafe-inline'` for scripts, exposing the app to XSS risks.
 **Learning:** To implement a strict CSP with nonce support for App Router, we must use Edge Middleware (now renamed to `proxy` in Next.js 16+). The `middleware.ts` file convention is deprecated in favor of `proxy.ts`, and the export must be named `proxy`.
 **Prevention:** Use `src/proxy.ts` to generate nonces and set dynamic CSP headers, allowing the removal of `'unsafe-inline'` from `script-src`. Ensure `style-src` retains `'unsafe-inline'` if using libraries like Framer Motion that inject styles at runtime.
+
+## 2026-02-21 - Strict CSP with Next.js App Router Nonce
+**Vulnerability:** The CSP implementation in `src/proxy.ts` generated a nonce but did not include it in the `script-src` directive, falling back to `'unsafe-inline'`, which is weak against XSS.
+**Learning:** Next.js App Router automatically injects nonces into scripts and preload links if the `x-nonce` header is present in the request. To leverage this, the CSP header must explicitly include `'nonce-${nonce}'` and ideally `'strict-dynamic'`. `'strict-dynamic'` allows modern browsers to execute trusted scripts while ignoring `'unsafe-inline'` and `'self'`, providing robust protection.
+**Prevention:** Update `src/proxy.ts` to include `'nonce-${nonce}'` and `'strict-dynamic'` in the `Content-Security-Policy` header. Ensure `x-nonce` is also set in the request headers so Next.js can pick it up.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,12 +6,16 @@ export function proxy(request: NextRequest) {
   const nonce = crypto.randomUUID()
 
   // Script-src:
-  // - 'self': Allows loading scripts from the same origin
-  // - 'unsafe-inline': Allows inline scripts (needed for Next.js)
+  // - 'self': Allows loading scripts from the same origin (ignored if strict-dynamic is present)
+  // - 'unsafe-inline': Allows inline scripts (ignored if nonce is present)
+  // - 'nonce-${nonce}': Allows scripts with the correct nonce
+  // - 'strict-dynamic': Allows scripts loaded by trusted scripts
   // - 'unsafe-eval': Only in development for Hot Module Replacement
   const scriptSrc = [
     "'self'",
     "'unsafe-inline'",
+    `'nonce-${nonce}'`,
+    "'strict-dynamic'",
     process.env.NODE_ENV === 'development' ? "'unsafe-eval'" : ""
   ].filter(Boolean).join(' ')
 


### PR DESCRIPTION
The application was generating a CSP nonce but not using it in the `script-src` directive, falling back to `'unsafe-inline'`, which allows any inline script to execute and exposes the application to XSS attacks.

This change updates `src/proxy.ts` to include `'nonce-${nonce}'` and `'strict-dynamic'` in the `Content-Security-Policy` header. This ensures that only scripts with the correct nonce (which Next.js automatically adds) can execute.

Verification:
- `curl -I` confirms the `Content-Security-Policy` header now includes `nonce-...` and `strict-dynamic`.
- `Link` headers for preloads also include the nonce, confirming Next.js is picking it up.

---
*PR created automatically by Jules for task [4644894733185797953](https://jules.google.com/task/4644894733185797953) started by @fakhriaditiarahman*